### PR TITLE
Edit view fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <table>
 <tr><th align="right" valign="top" nowrap>Plugin Name</th><td>JSM&#039;s Inherit Parent Featured Image</td></tr>
 <tr><th align="right" valign="top" nowrap>Summary</th><td>Inherit the featured image from the Post, Page, or Custom Post Type parent, grand-parent, great-grand-parent, etc.</td></tr>
-<tr><th align="right" valign="top" nowrap>Stable Version</th><td>1.3.0</td></tr>
+<tr><th align="right" valign="top" nowrap>Stable Version</th><td>1.3.1</td></tr>
 <tr><th align="right" valign="top" nowrap>Requires PHP</th><td>7.0 or newer</td></tr>
 <tr><th align="right" valign="top" nowrap>Requires WordPress</th><td>4.5 or newer</td></tr>
 <tr><th align="right" valign="top" nowrap>Tested Up To WordPress</th><td>5.7</td></tr>

--- a/inherit-featured-image.php
+++ b/inherit-featured-image.php
@@ -13,7 +13,7 @@
  * Requires PHP: 7.0
  * Requires At Least: 4.5
  * Tested Up To: 5.7
- * Version: 1.3.0
+ * Version: 1.3.1
  * 
  * Version Numbering: {major}.{minor}.{bugfix}[-{stage}.{level}]
  *
@@ -65,6 +65,14 @@ if ( ! class_exists( 'InheritFeaturedImage' ) ) {
 			 */
 			if ( $meta_key !== '_thumbnail_id' ) {
 
+				return $meta_data;
+			}
+
+			/**
+			 * We only care about the frontend. Do not show inherited image in backend editor.
+			 */
+			global $pagenow;
+			if (( $pagenow == 'post.php' ) || (get_post_type() == 'post')) {
 				return $meta_data;
 			}
 

--- a/inherit-featured-image.php
+++ b/inherit-featured-image.php
@@ -72,7 +72,8 @@ if ( ! class_exists( 'InheritFeaturedImage' ) ) {
 			 * We only care about the frontend. Do not show inherited image in backend editor.
 			 */
 			global $pagenow;
-			if (( $pagenow == 'post.php' ) || (get_post_type() == 'post')) {
+			if ( ( $pagenow == 'post.php' ) || ( get_post_type() == 'post' ) ) {
+
 				return $meta_data;
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Contributors: jsmoriss
 Requires PHP: 7.0
 Requires At Least: 4.5
 Tested Up To: 5.7
-Stable Tag: 1.3.0
+Stable Tag: 1.3.1
 
 Inherit the featured image from the Post, Page, or Custom Post Type parent, grand-parent, great-grand-parent, etc.
 


### PR DESCRIPTION
Fixes pages without their own featured image receiving an image via this plugin. Up to now editing a page without image resulted in the page setting the inherited picture as fixed for that child page.